### PR TITLE
8.0 hr loan config parameter

### DIFF
--- a/hr_loan/__openerp__.py
+++ b/hr_loan/__openerp__.py
@@ -28,7 +28,9 @@
     "depends": [
         'hr',
         'hr_payroll',
-        'hr_payroll_account'],
+        'hr_payroll_account',
+        'l10n_pa_hr_loan',
+    ],
     "author": "Vauxoo",
     "description": """
 Odoo HR Loan

--- a/hr_loan/__openerp__.py
+++ b/hr_loan/__openerp__.py
@@ -29,7 +29,6 @@
         'hr',
         'hr_payroll',
         'hr_payroll_account',
-        'l10n_pa_hr_loan',
     ],
     "author": "Vauxoo",
     "description": """

--- a/hr_loan/demo/hr_loan.xml
+++ b/hr_loan/demo/hr_loan.xml
@@ -50,5 +50,13 @@
     <record id="hr_payroll.hr_rule_basic" model="hr.salary.rule">
         <field name="account_debit" ref="hr_payroll_account.a_salary_expense"/>
     </record>
+<!--
+    ir.config_parameter for the calculation of hr loan ommigin the month
+    of December
+-->
+    <record id="ir_config_december" model="ir.config_parameter">
+        <field name="key">hr_loan.month_exception</field>
+        <field name="value">12</field>
+    </record>
   </data>
 </openerp>

--- a/hr_loan/demo/hr_loan.xml
+++ b/hr_loan/demo/hr_loan.xml
@@ -50,13 +50,5 @@
     <record id="hr_payroll.hr_rule_basic" model="hr.salary.rule">
         <field name="account_debit" ref="hr_payroll_account.a_salary_expense"/>
     </record>
-<!--
-    ir.config_parameter for the calculation of hr loan ommigin the month
-    of December
--->
-    <record id="ir_config_december" model="ir.config_parameter">
-        <field name="key">hr_loan.month_exception</field>
-        <field name="value">12</field>
-    </record>
   </data>
 </openerp>

--- a/hr_loan/demo/hr_loan.xml
+++ b/hr_loan/demo/hr_loan.xml
@@ -50,5 +50,13 @@
     <record id="hr_payroll.hr_rule_basic" model="hr.salary.rule">
         <field name="account_debit" ref="hr_payroll_account.a_salary_expense"/>
     </record>
+<!--
+    ir.config_parameter for the calculation of hr loan ommigin the month
+    of December
+-->
+    <record id="ir_config_december_demo" model="ir.config_parameter">
+        <field name="key">hr_loan.month_exception</field>
+        <field name="value">12</field>
+    </record>
   </data>
 </openerp>

--- a/hr_loan/model/hr_loan.py
+++ b/hr_loan/model/hr_loan.py
@@ -112,6 +112,25 @@ class hr_loan(osv.Model):
         return date.replace(month=date.month + 1, day=1) - timedelta(days=1)
 
     def compute_shares(self, cur, uid, ids, context=None):
+        """
+        This method calculates the loan for an employee given some params on
+        the form of hr_loan, this is by dividing the amount given on the loan
+        by the share quantity, and taking in account the start and end date
+        based on payment type:
+
+        Fields usage:
+
+            :param Name: A free char field where you can freely use.
+            :param Amount Approved: The amount base to make all compute.
+            :param Share Qty: The number of parts in which will bi divided
+            ´Amount approved´.
+            :param Payment Type: The time periodicity in which the employee
+            will pay.
+            :param Start Date: The date in which the employee will start making
+            payments.
+
+
+        """
         if context is None:
             context = {}
         ids = isinstance(ids, (int, long)) and [ids] or ids

--- a/hr_loan/model/hr_loan.py
+++ b/hr_loan/model/hr_loan.py
@@ -120,6 +120,7 @@ class hr_loan(osv.Model):
             old_loanline_ids = hr_loan_line_obj.search(
                 cur, uid, [('hr_loan_id', '=', hr_loan_brw.id)],
                 context=context)
+            # Delete previous loan lines if they exist
             if old_loanline_ids:
                 hr_loan_line_obj.unlink(
                     cur, uid, old_loanline_ids, context=context)

--- a/hr_loan/model/hr_loan.py
+++ b/hr_loan/model/hr_loan.py
@@ -177,6 +177,13 @@ class hr_loan(osv.Model):
                     current_date = current_date + relativedelta(days=7)
                 if hr_loan_brw.payment_type == 'monthly':
                     current_date = current_date + relativedelta(days=1)
+                    if current_date.month == \
+                            int(ir_cp_obj.get_param(cur, uid,
+                                                    str_rule,
+                                                    default=False,
+                                                    context=context)):
+                        current_date = current_date + \
+                            relativedelta(months=1)
                     current_date = self.last_day_of_month(current_date)
                 if hr_loan_brw.payment_type == 'bimonthly':
                     if ind == 0:

--- a/hr_loan/model/hr_loan.py
+++ b/hr_loan/model/hr_loan.py
@@ -134,6 +134,7 @@ class hr_loan(osv.Model):
         if context is None:
             context = {}
         ids = isinstance(ids, (int, long)) and [ids] or ids
+        str_rule = 'hr_loan.month_exception'
         hr_loan_line_obj = self.pool.get('hr.loan.line')
         ir_cp_obj = self.pool.get('ir.config_parameter')
         for hr_loan_brw in self.browse(cur, uid, ids, context=context):
@@ -160,7 +161,7 @@ class hr_loan(osv.Model):
                 # storing it on current_date variable
                 if current_date.month == \
                         int(ir_cp_obj.get_param(cur, uid,
-                                                'hr_loan.month_exception',
+                                                str_rule,
                                                 default=False,
                                                 context=context)):
                     current_date = current_date + relativedelta(months=1)
@@ -183,6 +184,13 @@ class hr_loan(osv.Model):
                         current_date = self.last_day_of_month(current_date)
                     else:
                         current_date = current_date + relativedelta(months=2)
+                        if current_date.month == \
+                                int(ir_cp_obj.get_param(cur, uid,
+                                                        str_rule,
+                                                        default=False,
+                                                        context=context)):
+                            current_date = current_date + \
+                                relativedelta(months=1)
                         current_date = self.last_day_of_month(current_date)
 
                 hr_loan_line_obj.create(cur, uid, {

--- a/hr_loan/tests/test_hr_loan_compute.py
+++ b/hr_loan/tests/test_hr_loan_compute.py
@@ -1,4 +1,4 @@
-#zn -*- encoding: utf-8 -*-
+# -*- encoding: utf-8 -*-
 ###############################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #    Copyright (C) OpenERP Venezuela (<http://www.vauxoo.com>).

--- a/hr_loan/tests/test_hr_loan_compute.py
+++ b/hr_loan/tests/test_hr_loan_compute.py
@@ -212,13 +212,13 @@ class TestLoanCompute(TransactionCase):
             self.share_test(loan_brw, 156.25)
             self.date_test_end(loan_brw, '2016-02-01')
             self.date_test(loan_brw, 0, '2014-10-31')
-            self.date_test(loan_brw, 1, '2014-02-28')
-            self.date_test(loan_brw, 2, '2015-04-30')
-            self.date_test(loan_brw, 3, '2015-06-30')
-            self.date_test(loan_brw, 4, '2015-08-31')
-            self.date_test(loan_brw, 5, '2015-10-31')
-            self.date_test(loan_brw, 6, '2016-02-29')
-            self.date_test(loan_brw, 7, '2016-04-30')
+            self.date_test(loan_brw, 1, '2014-12-31')
+            self.date_test(loan_brw, 2, '2015-02-28')
+            self.date_test(loan_brw, 3, '2015-04-30')
+            self.date_test(loan_brw, 4, '2015-06-30')
+            self.date_test(loan_brw, 5, '2015-08-31')
+            self.date_test(loan_brw, 6, '2015-10-31')
+            self.date_test(loan_brw, 7, '2016-02-29')
 
         return True
 

--- a/hr_loan/tests/test_hr_loan_compute.py
+++ b/hr_loan/tests/test_hr_loan_compute.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+#zn -*- encoding: utf-8 -*-
 ###############################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #    Copyright (C) OpenERP Venezuela (<http://www.vauxoo.com>).
@@ -210,15 +210,15 @@ class TestLoanCompute(TransactionCase):
             loan_brw = self.loan_list_brw[0]
 
             self.share_test(loan_brw, 156.25)
-            self.date_test_end(loan_brw, '2016-01-01')
+            self.date_test_end(loan_brw, '2016-02-01')
             self.date_test(loan_brw, 0, '2014-10-31')
-            self.date_test(loan_brw, 1, '2014-12-31')
-            self.date_test(loan_brw, 2, '2015-02-28')
-            self.date_test(loan_brw, 3, '2015-04-30')
-            self.date_test(loan_brw, 4, '2015-06-30')
-            self.date_test(loan_brw, 5, '2015-08-31')
-            self.date_test(loan_brw, 6, '2015-10-31')
-            self.date_test(loan_brw, 7, '2015-12-31')
+            self.date_test(loan_brw, 1, '2014-02-28')
+            self.date_test(loan_brw, 2, '2015-04-30')
+            self.date_test(loan_brw, 3, '2015-06-30')
+            self.date_test(loan_brw, 4, '2015-08-31')
+            self.date_test(loan_brw, 5, '2015-10-31')
+            self.date_test(loan_brw, 6, '2016-02-29')
+            self.date_test(loan_brw, 7, '2016-04-30')
 
         return True
 

--- a/hr_loan/tests/test_hr_loan_compute.py
+++ b/hr_loan/tests/test_hr_loan_compute.py
@@ -45,8 +45,8 @@ class TestLoanCompute(TransactionCase):
         self.loan_list_brw = list()
         self.payslip_brw = None
         self.loan_list = list()
-        self.bank_id = False
-        self.bank_id_2 = False
+        self.bank_id = None
+        self.bank_id_2 = None
 
     def create_period(self, fiscalyear_data, month):
         cr, uid = self.cr, self.uid

--- a/hr_loan/tests/test_hr_loan_compute.py
+++ b/hr_loan/tests/test_hr_loan_compute.py
@@ -212,13 +212,13 @@ class TestLoanCompute(TransactionCase):
             self.share_test(loan_brw, 156.25)
             self.date_test_end(loan_brw, '2016-02-01')
             self.date_test(loan_brw, 0, '2014-10-31')
-            self.date_test(loan_brw, 1, '2014-12-31')
-            self.date_test(loan_brw, 2, '2015-02-28')
-            self.date_test(loan_brw, 3, '2015-04-30')
-            self.date_test(loan_brw, 4, '2015-06-30')
-            self.date_test(loan_brw, 5, '2015-08-31')
-            self.date_test(loan_brw, 6, '2015-10-31')
-            self.date_test(loan_brw, 7, '2016-02-29')
+            self.date_test(loan_brw, 1, '2015-01-31')
+            self.date_test(loan_brw, 2, '2015-03-31')
+            self.date_test(loan_brw, 3, '2015-05-31')
+            self.date_test(loan_brw, 4, '2015-07-31')
+            self.date_test(loan_brw, 5, '2015-09-30')
+            self.date_test(loan_brw, 6, '2015-11-30')
+            self.date_test(loan_brw, 7, '2016-01-31')
 
         return True
 
@@ -239,17 +239,16 @@ class TestLoanCompute(TransactionCase):
     def loan_test_fortnightly(self):
         if self.loan_list_brw:
             loan_brw = self.loan_list_brw[0]
-
             self.share_test(loan_brw, 750)
-            self.date_test_end(loan_brw, '2015-06-01')
+            self.date_test_end(loan_brw, '2015-07-01')
             self.date_test(loan_brw, 0, '2014-10-31')
             self.date_test(loan_brw, 1, '2014-11-30')
-            self.date_test(loan_brw, 2, '2014-12-31')
-            self.date_test(loan_brw, 3, '2015-01-31')
-            self.date_test(loan_brw, 4, '2015-02-28')
-            self.date_test(loan_brw, 5, '2015-03-31')
-            self.date_test(loan_brw, 6, '2015-04-30')
-            self.date_test(loan_brw, 7, '2015-05-31')
+            self.date_test(loan_brw, 2, '2015-01-31')
+            self.date_test(loan_brw, 3, '2015-02-28')
+            self.date_test(loan_brw, 4, '2015-03-31')
+            self.date_test(loan_brw, 5, '2015-04-30')
+            self.date_test(loan_brw, 6, '2015-05-31')
+            self.date_test(loan_brw, 7, '2015-06-30')
 
         return True
 


### PR DESCRIPTION
calculation of loan now ommits the given month on the key 'hr_loan.month_exception' on the model ir.config_parameters established on the odoo-panama localization, also some comments on methods added.
